### PR TITLE
Dropped support for Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - "node"
   - "8"
   - "6"
-  - "4"
 addons:
   chrome: stable
 sudo: required

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 Two-player [cribbage](https://en.wikipedia.org/wiki/Cribbage) discard analysis tool.
 
 ## Installation
-* Install [Node.js 8 LTS](https://nodejs.org/en/download/),
-  [Node.js 6 LTS](https://nodejs.org/en/download/releases/) or
-  [Node.js 4](https://nodejs.org/en/download/releases/);
+* Install [Node.js 8 LTS](https://nodejs.org/en/download/) or
+  [Node.js 6 LTS](https://nodejs.org/en/download/releases/);
 * [clone this Git repository](https://help.github.com/articles/cloning-a-repository/); then
 * run `npm install` to download project operational and development dependencies.
 


### PR DESCRIPTION
Not supported by the Node.js foundation as of April 2018.